### PR TITLE
 Fix passing ssl_context to the TCPConnector and Fix isort and flake code style issues

### DIFF
--- a/aioelasticsearch/compat.py
+++ b/aioelasticsearch/compat.py
@@ -1,4 +1,3 @@
 import sys
 
-
 PY_352 = sys.version_info >= (3, 5, 2)

--- a/aioelasticsearch/connection.py
+++ b/aioelasticsearch/connection.py
@@ -65,7 +65,7 @@ class AIOHttpConnection(Connection):
                 if not self.verify_certs:
                     kwargs['ssl'] = False
                 else:
-                    ssl = ssl_context
+                    kwargs['ssl'] = ssl_context
             self.session = aiohttp.ClientSession(
                 auth=self.http_auth,
                 connector=aiohttp.TCPConnector(

--- a/aioelasticsearch/helpers.py
+++ b/aioelasticsearch/helpers.py
@@ -1,12 +1,11 @@
 import asyncio
-
 import logging
 
-from aioelasticsearch import NotFoundError
 from elasticsearch.helpers import ScanError
 
-from .compat import PY_352
+from aioelasticsearch import NotFoundError
 
+from .compat import PY_352
 
 __all__ = ('Scan', 'ScanError')
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4,12 +4,10 @@ from unittest import mock
 
 import aiohttp
 import pytest
-from aiohttp.test_utils import make_mocked_coro
 from elasticsearch import ConnectionTimeout
 
-from aioelasticsearch.connection import (
-    AIOHttpConnection, ConnectionError, SSLError,
-)
+from aioelasticsearch.connection import (AIOHttpConnection, ConnectionError,
+                                         SSLError)
 
 
 @pytest.mark.run_loop

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,4 +1,5 @@
 import asyncio
+import ssl
 from unittest import mock
 
 import aiohttp
@@ -29,6 +30,15 @@ async def test_custom_headers(auto_close, loop):
 async def test_auth_no_auth(auto_close, loop):
     conn = auto_close(AIOHttpConnection(loop=loop))
     assert conn.http_auth is None
+
+
+@pytest.mark.run_loop
+async def test_ssl_context(auto_close, loop):
+    context = ssl.create_default_context()
+    conn = auto_close(
+        AIOHttpConnection(loop=loop, verify_certs=True, ssl_context=context)
+    )
+    assert conn.session.connector._ssl is context
 
 
 @pytest.mark.run_loop

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,9 +1,7 @@
 import pytest
 
-
-from aioelasticsearch import (Elasticsearch, AIOHttpConnectionPool,
+from aioelasticsearch import (AIOHttpConnectionPool, Elasticsearch,
                               ImproperlyConfigured)
-
 from aioelasticsearch.pool import DummyConnectionPool
 
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,12 +1,10 @@
 import logging
-
 from unittest import mock
 
 import pytest
 
 from aioelasticsearch import NotFoundError
 from aioelasticsearch.helpers import Scan, ScanError
-
 
 logger = logging.getLogger('elasticsearch')
 
@@ -94,7 +92,7 @@ async def test_scan_equal_chunks_for_loop(es, es_clean, populate):
         ) as scan:
 
             async for doc in scan:
-                    ids.add(doc['_id'])
+                ids.add(doc['_id'])
 
             # check number of unique doc ids
             assert len(ids) == n == scan.total

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,8 +1,7 @@
 import pytest
 
-from aioelasticsearch import (Elasticsearch, ConnectionError,
-                              ConnectionTimeout, AIOHttpTransport,
-                              TransportError)
+from aioelasticsearch import (AIOHttpTransport, ConnectionError,
+                              ConnectionTimeout, Elasticsearch, TransportError)
 from aioelasticsearch.connection import AIOHttpConnection
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Currently, **tox** command execution fails during flake & isort issues. 
Fixed passing ssl_context to the TCPConnector and fixed isort and flake code style issues.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
Yes, changing how TCPConnector is initialized