### PR TITLE
Dropping support for aiohttp < 3.5.0, python < 3.5.3

### DIFF
--- a/aioelasticsearch/compat.py
+++ b/aioelasticsearch/compat.py
@@ -1,4 +1,0 @@
-import sys
-
-
-PY_352 = sys.version_info >= (3, 5, 2)

--- a/aioelasticsearch/connection.py
+++ b/aioelasticsearch/connection.py
@@ -1,5 +1,4 @@
 import asyncio
-from distutils.version import StrictVersion
 
 import aiohttp
 
@@ -58,14 +57,10 @@ class AIOHttpConnection(Connection):
         self.session = kwargs.get('session')
         if self.session is None:
             kwargs = {}
-            if StrictVersion(aiohttp.__version__).version < (3, 0):
-                kwargs['ssl_context'] = ssl_context
-                kwargs['verify_ssl'] = self.verify_certs
+            if not self.verify_certs:
+                kwargs['ssl'] = False
             else:
-                if not self.verify_certs:
-                    kwargs['ssl'] = False
-                else:
-                    ssl = ssl_context
+                kwargs['ssl'] = ssl_context
             self.session = aiohttp.ClientSession(
                 auth=self.http_auth,
                 connector=aiohttp.TCPConnector(

--- a/aioelasticsearch/helpers.py
+++ b/aioelasticsearch/helpers.py
@@ -1,11 +1,7 @@
-import asyncio
-
 import logging
 
 from aioelasticsearch import NotFoundError
 from elasticsearch.helpers import ScanError
-
-from .compat import PY_352
 
 
 __all__ = ('Scan', 'ScanError')
@@ -64,9 +60,6 @@ class Scan:
             raise RuntimeError("Scan operations should be done "
                                "inside async context manager")
         return self
-
-    if not PY_352:
-        __aiter__ = asyncio.coroutine(__aiter__)
 
     async def __anext__(self):  # noqa
         if self._done:

--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,12 @@ setup(
     version=get_version(),
     author='wikibusiness',
     author_email='osf@wikibusiness.org',
-    url='https://github.com/wikibusiness/aioelasticsearch',
+    url='https://github.com/aio-libs/aioelasticsearch',
     description='elasticsearch-py wrapper for asyncio',
     long_description=read('README.rst'),
     install_requires=[
         'elasticsearch>=6.0.0,<7.0.0',
-        'aiohttp>=2.3.7,<4.0.0',
+        'aiohttp>=3.5.0,<4.0.0',
     ],
     python_requires='>=3.5.3',
     packages=['aioelasticsearch'],
@@ -47,6 +47,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     keywords=['elasticsearch', 'asyncio', 'aiohttp'],
 )


### PR DESCRIPTION
## What do these changes do?

- Dropping support for aiohttp < 3.5.0
- Dropping support for python < 3.5.3
- Fixing missing ssl context for aiohttp.TCPConnector created by `aioelasticsearch.connection.AIOHttpConnection` 

## Are there changes in behavior for the user?

- Dropping support for aiohttp < 3.5.0
- Dropping support for python < 3.5.3

## Related issue number

https://github.com/aio-libs/aioelasticsearch/issues/155
https://github.com/aio-libs/aioelasticsearch/issues/154

## Checklist

- [ x ] I think the code is well written
- [ x ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
