### PR TITLE
Elasticsearch 7 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,17 @@ aioelasticsearch
 Installation
 ------------
 
+For elasticsearch < 7:
+
 .. code-block:: shell
 
-    pip install aioelasticsearch
+    pip install aioelasticsearch[6]
+
+For elasticsearch >= 7:
+
+.. code-block:: shell
+
+    pip install aioelasticsearch[7]
 
 Usage
 -----
@@ -56,7 +64,7 @@ Asynchronous `scroll <https://www.elastic.co/guide/en/elasticsearch/reference/cu
             async with Scan(
                 es,
                 index='index',
-                doc_type='doc_type',
+                doc_type='doc_type',  # omit this for Elasticsearch 7
                 query={},
             ) as scan:
                 print(scan.total)

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,12 @@ setup(
     description='elasticsearch-py wrapper for asyncio',
     long_description=read('README.rst'),
     install_requires=[
-        'elasticsearch>=6.0.0,<7.0.0',
         'aiohttp>=3.5.0,<4.0.0',
     ],
+    extras_require={
+        '6': ['elasticsearch>=6.0.0,<7.0.0'],
+        '7': ['elasticsearch>=7.0.0,<8.0.0'],
+    },
     python_requires='>=3.5.3',
     packages=['aioelasticsearch'],
     include_package_data=True,

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -161,10 +161,49 @@ async def test_mark_dead_with_sniff(auto_close, loop, es_server):
     assert len(t.connection_pool.connections) == 1
 
 
+@pytest.mark.skip_before_es7
 @pytest.mark.run_loop
-async def test_send_get_body_as_post(es_server, auto_close, loop):
+async def test_send_get_body_as_post_after_es7(es_server, auto_close, loop):
     cl = auto_close(Elasticsearch([{'host': es_server['host'],
                                    'port': es_server['port']}],
+                                  send_get_body_as='POST',
+                                  http_auth=es_server['auth'],
+                                  loop=loop))
+    await cl.create('test', '1', {'val': '1'})
+    await cl.create('test', '2', {'val': '2'})
+    ret = await cl.mget(
+        {"docs": [
+                {"_id": "1"},
+                {"_id": "2"}
+        ]},
+        index='test', )
+    assert ret == {'docs': [{'_id': '1',
+                             '_index': 'test',
+                             '_source': {'val': '1'},
+
+                             '_version': 1,
+                             '_primary_term': 1,
+                             'found': True,
+                             '_seq_no': 0,
+                             '_type': '_doc',
+                             },
+                            {'_id': '2',
+                             '_index': 'test',
+                             '_source': {'val': '2'},
+
+                             '_version': 1,
+                             '_primary_term': 1,
+                             'found': True,
+                             '_seq_no': 1,
+                             '_type': '_doc',
+                             }]}
+
+
+@pytest.mark.skip_after_es7
+@pytest.mark.run_loop
+async def test_send_get_body_as_post_before_es7(es_server, auto_close, loop):
+    cl = auto_close(Elasticsearch([{'host': es_server['host'],
+                                    'port': es_server['port']}],
                                   send_get_body_as='POST',
                                   http_auth=es_server['auth'],
                                   loop=loop))
@@ -172,8 +211,8 @@ async def test_send_get_body_as_post(es_server, auto_close, loop):
     await cl.create('test', 'type', '2', {'val': '2'})
     ret = await cl.mget(
         {"docs": [
-                {"_id": "1"},
-                {"_id": "2"}
+            {"_id": "1"},
+            {"_id": "2"}
         ]},
         index='test', doc_type='type')
     assert ret == {'docs': [{'_id': '1',
@@ -190,8 +229,47 @@ async def test_send_get_body_as_post(es_server, auto_close, loop):
                              'found': True}]}
 
 
+@pytest.mark.skip_before_es7
 @pytest.mark.run_loop
-async def test_send_get_body_as_source(es_server, auto_close, loop):
+async def test_send_get_body_as_source_after_es7(es_server, auto_close, loop):
+    cl = auto_close(Elasticsearch([{'host': es_server['host'],
+                                   'port': es_server['port']}],
+                                  send_get_body_as='source',
+                                  http_auth=es_server['auth'],
+                                  loop=loop))
+    await cl.create('test', '1', {'val': '1'})
+    await cl.create('test', '2', {'val': '2'})
+    ret = await cl.mget(
+        {"docs": [
+                {"_id": "1"},
+                {"_id": "2"}
+        ]},
+        index='test', )
+    assert ret == {'docs': [{'_id': '1',
+                             '_index': 'test',
+                             '_source': {'val': '1'},
+
+                             '_version': 1,
+                             '_primary_term': 1,
+                             'found': True,
+                             '_seq_no': 0,
+                             '_type': '_doc',
+                             },
+                            {'_id': '2',
+                             '_index': 'test',
+                             '_source': {'val': '2'},
+
+                             '_version': 1,
+                             '_primary_term': 1,
+                             'found': True,
+                             '_seq_no': 1,
+                             '_type': '_doc',
+                             }]}
+
+
+@pytest.mark.skip_after_es7
+@pytest.mark.run_loop
+async def test_send_get_body_as_source_before_es7(es_server, auto_close, loop):
     cl = auto_close(Elasticsearch([{'host': es_server['host'],
                                    'port': es_server['port']}],
                                   send_get_body_as='source',
@@ -219,18 +297,57 @@ async def test_send_get_body_as_source(es_server, auto_close, loop):
                              'found': True}]}
 
 
+@pytest.mark.skip_before_es7
 @pytest.mark.run_loop
-async def test_send_get_body_as_get(es_server, auto_close, loop):
+async def test_send_get_body_as_get_after_es7(es_server, auto_close, loop):
     cl = auto_close(Elasticsearch([{'host': es_server['host'],
                                    'port': es_server['port']}],
+                                  http_auth=es_server['auth'],
+                                  loop=loop))
+    await cl.create('test', '1', {'val': '1'})
+    await cl.create('test', '2', {'val': '2'})
+    ret = await cl.mget(
+        {"docs": [
+                {"_id": "1"},
+                {"_id": "2"}
+        ]},
+        index='test', )
+    assert ret == {'docs': [{'_id': '1',
+                             '_index': 'test',
+                             '_source': {'val': '1'},
+
+                             '_version': 1,
+                             '_primary_term': 1,
+                             'found': True,
+                             '_seq_no': 0,
+                             '_type': '_doc',
+                             },
+                            {'_id': '2',
+                             '_index': 'test',
+                             '_source': {'val': '2'},
+
+
+                             '_version': 1,
+                             '_primary_term': 1,
+                             'found': True,
+                             '_seq_no': 1,
+                             '_type': '_doc',
+                             }]}
+
+
+@pytest.mark.skip_after_es7
+@pytest.mark.run_loop
+async def test_send_get_body_as_get_before_es7(es_server, auto_close, loop):
+    cl = auto_close(Elasticsearch([{'host': es_server['host'],
+                                    'port': es_server['port']}],
                                   http_auth=es_server['auth'],
                                   loop=loop))
     await cl.create('test', 'type', '1', {'val': '1'})
     await cl.create('test', 'type', '2', {'val': '2'})
     ret = await cl.mget(
         {"docs": [
-                {"_id": "1"},
-                {"_id": "2"}
+            {"_id": "1"},
+            {"_id": "2"}
         ]},
         index='test', doc_type='type')
     assert ret == {'docs': [{'_id': '1',
@@ -247,11 +364,51 @@ async def test_send_get_body_as_get(es_server, auto_close, loop):
                              'found': True}]}
 
 
+@pytest.mark.skip_before_es7
 @pytest.mark.run_loop
-async def test_send_get_body_as_source_none_params(es_server,
-                                                   auto_close, loop):
+async def test_send_get_body_as_source_none_params_after_es7(es_server,
+                                                             auto_close, loop):
     cl = auto_close(Elasticsearch([{'host': es_server['host'],
                                    'port': es_server['port']}],
+                                  send_get_body_as='source',
+                                  http_auth=es_server['auth'],
+                                  loop=loop))
+    await cl.create('test', '1', {'val': '1'})
+    await cl.create('test', '2', {'val': '2'})
+    ret = await cl.transport.perform_request(
+        'GET', 'test/_mget',
+        body={"docs": [
+            {"_id": "1"},
+            {"_id": "2"}
+        ]})
+    assert ret == {'docs': [{'_id': '1',
+                             '_index': 'test',
+                             '_source': {'val': '1'},
+
+                             '_version': 1,
+                             '_primary_term': 1,
+                             'found': True,
+                             '_seq_no': 0,
+                             '_type': '_doc',
+                             },
+                            {'_id': '2',
+                             '_index': 'test',
+                             '_source': {'val': '2'},
+
+                             '_version':  1,
+                             '_primary_term': 1,
+                             'found': True,
+                             '_seq_no': 1,
+                             '_type': '_doc',
+                             }]}
+
+
+@pytest.mark.skip_after_es7
+@pytest.mark.run_loop
+async def test_send_get_body_as_source_none_params_before_es7(es_server,
+                                                              auto_close, loop):
+    cl = auto_close(Elasticsearch([{'host': es_server['host'],
+                                    'port': es_server['port']}],
                                   send_get_body_as='source',
                                   http_auth=es_server['auth'],
                                   loop=loop))


### PR DESCRIPTION
## What do these changes do?

Changing setup.py to support both ES 6 and ES 7 via extras_require in setup.py. Omitting it will render library broken.  
Tests are rewritten to support both versions. 

## Are there changes in behavior for the user?

Support for ES7, the installation now requires an explicit version in square brackets: 
```
pip install aioelasticsearch[6]
```
 or 
```
pip install aioelasticsearch[7]
```

## Related issue number

https://github.com/aio-libs/aioelasticsearch/issues/158

## Checklist

- [ x ] I think the code is well written
- [ x ] Unit tests for the changes exist
- [ x ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
