### PR TITLE
Fix AttributeError for Elasticsearch>2.0.0,<3.0.0

### DIFF
--- a/aioelasticsearch/connection.py
+++ b/aioelasticsearch/connection.py
@@ -49,7 +49,7 @@ class AIOHttpConnection(Connection):
 
         self.verify_certs = verify_certs
 
-        self.base_url = URL.build(scheme='https' if self.use_ssl else 'http',
+        self.base_url = URL.build(scheme='https' if use_ssl else 'http',
                                   host=host,
                                   port=port,
                                   path=self.url_prefix)


### PR DESCRIPTION
AIOHttpConnection takes use_ssl argument and passes one to the parent's __init__.

Then self.use_ssl gets used instead of use_ssl here
https://github.com/aio-libs/aioelasticsearch/blob/master/aioelasticsearch/connection.py#L52

It works for the latest elasticsearch-py versions, however, it doesn't work with >2.0.0, b/c there's no self.use_ssl = use_ssl there.

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
