### PR TITLE
default hits.hits to empty list

### DIFF
--- a/aioelasticsearch/helpers.py
+++ b/aioelasticsearch/helpers.py
@@ -134,7 +134,7 @@ class Scan:
             )
 
     def _update_state(self, resp):
-        self._hits = resp['hits']['hits']
+        self._hits = resp['hits'].get('hits', [])
         self._hits_idx = 0
         self._scroll_id = resp.get('_scroll_id')
         self._successful_shards = resp['_shards']['successful']


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

default hits.hits to empty list in Scan operation

## Are there changes in behavior for the user?

Yes, now you can supply filter_path

```python
filter_paths=[
"-hits.hits._index"
]
Scan(query, scroll_kwargs=dict(filter_path=filter_paths)))
```
and still get a *hits.hits* key back, which the Scan operation is expecting.

## Related issue number

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
