### PR TITLE
implement scan composite aggregation

### DIFF
--- a/aioelasticsearch/helpers.py
+++ b/aioelasticsearch/helpers.py
@@ -1,10 +1,12 @@
+import asyncio
 import logging
+from copy import deepcopy
 
 from elasticsearch.helpers import ScanError
 
-from aioelasticsearch import NotFoundError
+from aioelasticsearch import ElasticsearchException, NotFoundError
 
-__all__ = ('Scan', 'ScanError')
+__all__ = ('CompositeAggregationScan', 'Scan', 'ScanError')
 
 
 logger = logging.getLogger('elasticsearch')
@@ -140,3 +142,147 @@ class Scan:
         self._successful_shards = resp['_shards']['successful']
         self._total_shards = resp['_shards']['total']
         self._done = not self._hits or self._scroll_id is None
+
+
+class CompositeAggregationScan:
+
+    def __init__(
+        self,
+        es,
+        query,
+        raise_on_error=True,
+        prefetch_next_chunk=False,
+        **kwargs,
+    ):
+        self._es = es
+        self._query = deepcopy(query)
+        self._raise_on_error = raise_on_error
+        self._prefetch_next_chunk = prefetch_next_chunk
+        self._kwargs = kwargs
+
+        self._aggs_key = self._extract_aggs_key()
+
+        if 'composite' not in self._query['aggs'][self._aggs_key]:
+            raise RuntimeError(
+                'Scroll available only for composite aggregations.',
+            )
+
+        self._after_key = None
+
+        self._initial = True
+        self._done = False
+        self._buckets = []
+        self._buckets_idx = 0
+
+        self._successful_shards = 0
+        self._total_shards = 0
+        self._prefetched = None
+
+    def _extract_aggs_key(self):
+        try:
+            return list(self._query['aggs'].keys())[0]
+        except (KeyError, IndexError):
+            raise RuntimeError(
+                "Can't get aggregation key from query {query}."
+                .format(query=self._query),
+            )
+
+    async def __aenter__(self):  # noqa
+        self._initial = False
+        await self._fetch_results()
+
+        return self
+
+    async def __aexit__(self, *exc_info):  # noqa
+        self._reset_prefetched()
+
+    def __aiter__(self):
+        if self._initial:
+            raise RuntimeError(
+                'Scan operations should be done '
+                'inside async context manager.',
+            )
+
+        return self
+
+    async def __anext__(self):
+        if self._done:
+            raise StopAsyncIteration
+
+        if self._buckets_idx >= len(self._buckets):
+            if self._successful_shards < self._total_shards:
+                logger.warning(
+                    'Aggregation request has only succeeded '
+                    'on %d shards out of %d.',
+                    self._successful_shards, self._total_shards,
+                )
+                if self._raise_on_error:
+                    raise ElasticsearchException(
+                        'Aggregation request has only succeeded '
+                        'on %d shards out of %d.'
+                        .format(self._successful_shards, self._total_shards),
+                    )
+
+            await self._fetch_results()
+            if self._done:
+                raise StopAsyncIteration
+
+        ret = self._buckets[self._buckets_idx]
+        self._buckets_idx += 1
+
+        return ret
+
+    async def _search(self):
+        found, resp = True, None
+        try:
+            resp = await self._es.search(
+                body=self._query,
+                **self._kwargs,
+            )
+        except NotFoundError:
+            found = False
+
+        return found, resp
+
+    def _reset_prefetched(self):
+        if self._prefetched is not None and not self._prefetched.cancelled():  # noqa
+            self._prefetched.cancel()
+
+        self._prefetched = None
+
+    async def _fetch_results(self):
+        if self._prefetched is not None:
+            found, resp = await self._prefetched
+            self._reset_prefetched()
+        else:
+            found, resp = await self._search()
+
+        if not found:
+            self._done = True
+
+            return
+
+        self._update_state(resp)
+
+        if self._prefetch_next_chunk:
+            self._prefetched = asyncio.create_task(
+                self._search(),
+            )
+
+    def _update_query(self):
+        if self._after_key is None:
+            return
+
+        self._query['aggs'][self._aggs_key]['composite']['after'] = self._after_key  # noqa
+
+    def _update_state(self, resp):
+        self._after_key = resp['aggregations'][self._aggs_key].get('after_key')
+        self._buckets = resp['aggregations'][self._aggs_key]['buckets']
+        self._buckets_idx = 0
+
+        self._update_query()
+
+        self._successful_shards = resp['_shards']['successful']
+        self._total_shards = resp['_shards']['total']
+
+        self._done = not self._buckets or self._after_key is None

--- a/tests/test_composite_scan.py
+++ b/tests/test_composite_scan.py
@@ -1,0 +1,275 @@
+import asyncio
+import logging
+from copy import deepcopy
+from unittest import mock
+
+import pytest
+
+from aioelasticsearch import ElasticsearchException
+from aioelasticsearch.helpers import CompositeAggregationScan
+
+logger = logging.getLogger('elasticsearch')
+
+
+ES_DATA = [
+    {
+        'score': '1',
+    },
+    {
+        'score': '2',
+    },
+    {
+        'score': '2',
+    },
+    {
+        'score': '3',
+    },
+    {
+        'score': '3',
+    },
+    {
+        'score': '3',
+    },
+]
+
+
+QUERY = {
+    'aggs': {
+        'buckets': {
+            'composite': {
+                'sources': [
+                    {'score': {'terms': {'field': 'score.keyword'}}},
+                ],
+            },
+        },
+    },
+}
+
+INDEX = 'test_aioes'
+
+
+@pytest.fixture
+def populate_aggs_data(loop, es):
+
+    async def do(index, docs):
+        coros = []
+
+        await es.indices.create(index)
+
+        for i, doc in enumerate(docs):
+            coros.append(
+                es.index(
+                    index=index,
+                    id=str(i),
+                    body=doc,
+                ),
+            )
+
+        await asyncio.gather(*coros, loop=loop)
+        await es.indices.refresh()
+
+    return do
+
+
+@pytest.mark.run_loop
+async def test_async_for_without_context_manager(es):
+    scan = CompositeAggregationScan(es, QUERY)
+
+    with pytest.raises(RuntimeError):
+        async for doc in scan:
+            doc
+
+
+@pytest.mark.run_loop
+async def test_non_aggregation_query(es):
+    with pytest.raises(RuntimeError):
+        CompositeAggregationScan(
+            es,
+            {
+                'query': {
+                    'bool': {
+                        'match_all': {},
+                    },
+                },
+            },
+        )
+
+
+@pytest.mark.run_loop
+async def test_non_composite_aggregation(es):
+    with pytest.raises(RuntimeError):
+        CompositeAggregationScan(
+            es,
+            {
+                'query': {
+                    'aggs': {
+                        'counts': {
+                            'value_count': {'field': 'domains'},
+                        },
+                    },
+                },
+            },
+        )
+
+
+@pytest.mark.run_loop
+async def test_scan(es, populate_aggs_data):
+    await populate_aggs_data(INDEX, ES_DATA)
+
+    async with CompositeAggregationScan(
+        es,
+        QUERY,
+        index=INDEX,
+    ) as scan:
+        i = 1
+        async for doc in scan:
+            assert doc == {
+                'key': {'score': str(i)},
+                'doc_count': i,
+            }
+
+            i += 1
+
+        assert i == 4
+
+
+@pytest.mark.run_loop
+async def test_scan_no_index(es, populate_aggs_data):
+    await populate_aggs_data(INDEX, ES_DATA)
+
+    async with CompositeAggregationScan(
+        es,
+        QUERY,
+    ) as scan:
+        i = 1
+        async for doc in scan:
+            assert doc == {
+                'key': {'score': str(i)},
+                'doc_count': i,
+            }
+
+            i += 1
+
+        assert i == 4
+
+
+@pytest.mark.run_loop
+async def test_scan_multiple_fetch(es, populate_aggs_data):
+    await populate_aggs_data(INDEX, ES_DATA)
+
+    q = deepcopy(QUERY)
+    q['aggs']['buckets']['composite']['size'] = 1
+
+    async with CompositeAggregationScan(
+        es,
+        q,
+        index=INDEX,
+    ) as scan:
+        i = 1
+        original_update = scan._update_state
+        mock_update = mock.MagicMock(side_effect=original_update)
+        with mock.patch.object(scan, '_update_state', mock_update):
+
+            async for doc in scan:
+                assert doc == {
+                    'key': {'score': str(i)},
+                    'doc_count': i,
+                }
+
+                i += 1
+
+            assert mock_update.call_count == 3
+
+
+@pytest.mark.run_loop
+async def test_scan_with_prefetch_next(es, populate_aggs_data):
+    await populate_aggs_data(INDEX, ES_DATA)
+
+    q = deepcopy(QUERY)
+    q['aggs']['buckets']['composite']['size'] = 1
+
+    async with CompositeAggregationScan(
+        es,
+        q,
+        prefetch_next_chunk=True,
+        index=INDEX,
+    ) as scan:
+        original_reset_prefetch = scan._reset_prefetched
+        mock_reset_prefetch = mock.MagicMock(
+            side_effect=original_reset_prefetch,
+        )
+        with mock.patch.object(
+            scan,
+            '_reset_prefetched',
+            mock_reset_prefetch,
+        ):
+            async for _ in scan:  # noqa
+                assert scan._prefetched is not None
+
+            assert mock_reset_prefetch.call_count == 3
+
+            last_prefetch_task = scan._prefetched
+
+    await asyncio.sleep(0)
+
+    assert last_prefetch_task.cancelled()
+    assert scan._prefetched is None
+
+
+@pytest.mark.run_loop
+async def test_scan_warning_on_failed_shards(
+    es,
+    populate_aggs_data,
+    mocker,
+):
+    mocker.spy(logger, 'warning')
+
+    await populate_aggs_data(INDEX, ES_DATA)
+
+    async with CompositeAggregationScan(
+        es,
+        QUERY,
+        raise_on_error=False,
+        index=INDEX,
+    ) as scan:
+        i = 0
+        async for doc in scan:  # noqa
+            if i == 1:
+                scan._successful_shards = 4
+                scan._total_shards = 5
+            i += 1
+
+    logger.warning.assert_called_once_with(
+        'Aggregation request has only succeeded on %d shards out of %d.',
+        4,
+        5,
+    )
+
+
+@pytest.mark.run_loop
+async def test_scan_exception_on_failed_shards(
+    es,
+    populate_aggs_data,
+    mocker,
+):
+    mocker.spy(logger, 'warning')
+
+    await populate_aggs_data(INDEX, ES_DATA)
+
+    async with CompositeAggregationScan(
+        es,
+        QUERY,
+        index=INDEX,
+    ) as scan:
+        i = 0
+        with pytest.raises(ElasticsearchException):
+            async for doc in scan:  # noqa
+                if i == 1:
+                    scan._successful_shards = 4
+                    scan._total_shards = 5
+                i += 1
+
+    assert i == 3
+    logger.warning.assert_called_once_with(
+        'Aggregation request has only succeeded on %d shards out of %d.', 4, 5,
+    )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Added convenient scan for composite aggregations as specified in [es docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html#_pagination).

## Are there changes in behavior for the user?

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
