### PR TITLE
Deprecate loop argument

### DIFF
--- a/aioelasticsearch/__init__.py
+++ b/aioelasticsearch/__init__.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from elasticsearch import Elasticsearch as _Elasticsearch  # noqa # isort:skip
 from elasticsearch.connection_pool import (ConnectionSelector, # noqa # isort:skip
                                            RoundRobinSelector)
@@ -23,12 +21,8 @@ class Elasticsearch(_Elasticsearch):
         loop=None,
         **kwargs
     ):
-        if loop is None:
-            loop = asyncio.get_event_loop()
-
-        self.loop = loop
-
-        kwargs['loop'] = self.loop
+        if loop is not None:
+            kwargs['loop'] = loop
 
         super().__init__(hosts, transport_class=transport_class, **kwargs)
 

--- a/aioelasticsearch/connection.py
+++ b/aioelasticsearch/connection.py
@@ -35,7 +35,7 @@ class AIOHttpConnection(Connection):
         maxsize=10,
         headers=None,
         *,
-        loop,
+        loop=None,
         **kwargs
     ):
         assert not(
@@ -50,6 +50,8 @@ class AIOHttpConnection(Connection):
         self.headers = headers
         self.headers.setdefault('Content-Type', 'application/json')
 
+        if loop is None:
+            loop = asyncio.get_event_loop()
         self.loop = loop
 
         if http_auth is not None:

--- a/aioelasticsearch/pool.py
+++ b/aioelasticsearch/pool.py
@@ -20,7 +20,7 @@ class AIOHttpConnectionPool:
         selector_class=RoundRobinSelector,
         randomize_hosts=True,
         *,
-        loop,
+        loop=None,
         **kwargs
     ):
         self._dead_timeout = dead_timeout
@@ -31,6 +31,8 @@ class AIOHttpConnectionPool:
         self.dead = asyncio.PriorityQueue(len(self.connections), loop=loop)
         self.dead_count = collections.Counter()
 
+        if loop is None:
+            loop = asyncio.get_event_loop()
         self.loop = loop
 
         if randomize_hosts:
@@ -122,6 +124,8 @@ class DummyConnectionPool(AIOHttpConnectionPool):
                 'DummyConnectionPool needs exactly one connection defined.',
             )
 
+        if loop is None:
+            loop = asyncio.get_event_loop()
         self.loop = loop
 
         self.connection_opts = connections

--- a/aioelasticsearch/transport.py
+++ b/aioelasticsearch/transport.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import warnings
 from itertools import chain, count
 
 from elasticsearch.serializer import (DEFAULT_SERIALIZERS, Deserializer,
@@ -34,9 +35,15 @@ class AIOHttpTransport(Transport):
         retry_on_timeout=False,
         send_get_body_as='GET',
         *,
-        loop,
+        loop=None,
         **kwargs
     ):
+        if loop is not None:
+            warnings.warn(
+                "loop argument is deprecated", DeprecationWarning, stacklevel=2
+            )
+        else:
+            loop = asyncio.get_event_loop()
         self.loop = loop
         self._closed = False
 
@@ -71,7 +78,7 @@ class AIOHttpTransport(Transport):
         # store all strategies...
         self.connection_pool_class = connection_pool_class
         self.connection_class = connection_class
-        self._connection_pool_lock = asyncio.Lock(loop=self.loop)
+        self._connection_pool_lock = asyncio.Lock()
 
         # ...save kwargs to be passed to the connections
         self.kwargs = kwargs


### PR DESCRIPTION
## What do these changes do?

This PR deprecates `loop` keyword argument as it deprecated for `asyncio.Lock` in python3.8 and generates warnings.

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
