### PR TITLE
fix: remove loop argument from asyncio calls

### DIFF
--- a/aioelasticsearch/transport.py
+++ b/aioelasticsearch/transport.py
@@ -71,7 +71,7 @@ class AIOHttpTransport(Transport):
         # store all strategies...
         self.connection_pool_class = connection_pool_class
         self.connection_class = connection_class
-        self._connection_pool_lock = asyncio.Lock(loop=self.loop)
+        self._connection_pool_lock = asyncio.Lock()
 
         # ...save kwargs to be passed to the connections
         self.kwargs = kwargs
@@ -219,7 +219,7 @@ class AIOHttpTransport(Transport):
 
         coros.append(self.connection_pool.close())
 
-        await asyncio.gather(*coros, loop=self.loop)
+        await asyncio.gather(*coros)
         self._closed = True
 
     async def get_connection(self):


### PR DESCRIPTION
The loop parameter was removed in python 3.10 and causes a TypeError there:

~~~
   File "/usr/local/lib/python3.10/site-packages/aioelasticsearch/__init__.py", line 33, in __init__                                                                                                                                                                                                                                                        
     super().__init__(hosts, transport_class=transport_class, **kwargs)                                                                                                                                                                                                                                                                                        
   File "/usr/local/lib/python3.10/site-packages/elasticsearch/client/__init__.py", line 205, in __init__                                                                                                                                                                                                                                                         
     self.transport = transport_class(_normalize_hosts(hosts), **kwargs)                                                                                                                                                                                                                                                                                       
  File "/usr/local/lib/python3.10/site-packages/aioelasticsearch/transport.py", line 74, in __init__                                                                                                                                                                                                                                                       
     self._connection_pool_lock = asyncio.Lock(loop=self.loop)                                                                                                                                                                                                                                                                                                 
  File "/usr/local/lib/python3.10/asyncio/locks.py", line 77, in __init__                                                                                                                                                                                                                                                                                       
    super().__init__(loop=loop)                                                                                                                                                                                                                                                                                                                                
  File "/usr/local/lib/python3.10/asyncio/mixins.py", line 17, in __init__                                                                                                                                                                                                                                                                                      
    raise TypeError(                                                                                                                                                                                                                                                                                                                                         TypeError: As of 3.10, the *loop* parameter was removed from Lock() since it is no longer necessary 
~~~


## Are there changes in behavior for the user?

It might not work as expected anymore if the user tries to use a loop that is not the defauult loop for the current thread - but it seems that this is not supported by python anymore anyway.

## Related issue number

None to my knowledge.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
